### PR TITLE
Add "Conda" package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Any contribution is welcome!
 * [Ecosystem](https://github.com/PeregrineLabs/Ecosystem)
 * [Rez](https://github.com/nerdvegas/rez)
 * [Rez Packages](https://github.com/predat/rez-packages)
+* [conda](https://github.com/conda/conda)
 
 ## Asset managers
 


### PR DESCRIPTION
Conda is a cross-platform, Python-agnostic package manager capable of handling binaries and source code.

You can read more here: https://conda.readthedocs.io/en/latest/

Unlike the Rez package manager often used in VFX, Conda downloads a package version and actually "installs" it locally when it is requested, allowing many versions to coexist of course. The environments are assembled through an internal mechanism employing hardlinks (so the same package used by various environments is disk-space-efficient.)

Also unlike Rez, Conda can source both "conda packages" and pip packages straight off PyPi treating them as equal citizens, so if you need a popular pip module, you don't really have to make a package for it.

It's extremely popular in the Python data science circles and most popular opensource libraries have some conda package already made for it.

The PyPi equivalent of Conda is the Conda Forge: https://conda-forge.org/feedstocks/
