### PR TITLE
Add Tool Chef's Kiko animation curves file format project

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Any contribution is welcome!
 * [OpenEXRid](https://github.com/MercenariesEngineering/openexrid) - Object isolation
 * [OpenTimelineIO](https://github.com/PixarAnimationStudios/OpenTimelineIO) - Editorial timeline
 * [USD](http://graphics.pixar.com/usd/docs/index.html) - Scenes
+* [Kiko](https://github.com/Toolchefs/kiko) - DCC-agnostic animation curves storage. (Works between Maya and Nuke, with more DCCs to come.)
 
 ## Job schedulers
 


### PR DESCRIPTION
New project from the folks at _Tool Chefs_, **Kiko** (Keys In Keys Out) aims to be a DCC agnostic file format for animation curves.

Currently supports Maya and Nuke. They're looking for contributors to add support for other softwares like Houdini and Katana.

More info (and a few videos) here: https://www.toolchefs.com/?portfolio=kiko
