### PR TITLE
Add Psyop's Cryptomatte project

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Any contribution is welcome!
 
 * [Alembic](http://www.alembic.io/) - Animations
 * [ACES](http://www.oscars.org/science-technology/sci-tech-projects/aces) - Color management
+* [Cryptomatte](https://github.com/Psyop/Cryptomatte) - Accurate object ID mattes
 * [MaterialX](https://github.com/materialx/MaterialX) - Materials and look-dev
 * [OpenEXRid](https://github.com/MercenariesEngineering/openexrid) - Object isolation
 * [OpenTimelineIO](https://github.com/PixarAnimationStudios/OpenTimelineIO) - Editorial timeline


### PR DESCRIPTION
Psyop's _Cryptomatte_ makes storing highly accurate object ID mattes and using them super easy.

Demo video: https://vimeo.com/136954966
